### PR TITLE
fix empty result for not multiexecution

### DIFF
--- a/backend/app_sdk/app_base.py
+++ b/backend/app_sdk/app_base.py
@@ -815,6 +815,7 @@ class AppBase:
                                     result += "Failed autocasting. Can't handle %s type from function. Must be string" % type(newres)
                                     print("Can't handle type %s value from function" % (type(newres)))
                             print("POST NEWRES: ", newres)
+                            result = newres
                         else:
                             print("APP_SDK DONE: Starting MULTI execution with", multi_parameters)
                             # 1. Use number of executions based on longest array


### PR DESCRIPTION
Cortex App got empty result until I added that line.
TODO: figure out why it's not detecting as JSON, like on screenshot below:
![image](https://user-images.githubusercontent.com/37391150/86741721-479af900-c040-11ea-9b73-1d7c09309d8a.png)
