### PR TITLE
frontend - wait for backend readiness

### DIFF
--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# prepare variables
+BACKEND_HOSTNAME=${BACKEND_HOSTNAME:-shuffle-backend}
+
+# wait for backend readiness
+while [ "$(curl -s http://$BACKEND_HOSTNAME:5001/api/v1/_ah/health)" != "OK" ]; do
+    echo "Waiting for backend readiness..."
+    sleep 5
+done
+
 # generate configs
 /usr/local/bin/confd -backend="env" -confdir="/etc/confd" -onetime
 

--- a/functions/onprem/orborus/Dockerfile
+++ b/functions/onprem/orborus/Dockerfile
@@ -8,7 +8,10 @@ RUN go get github.com/docker/docker/api/types github.com/docker/docker/api/types
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o orborus .
 
-from scratch
+FROM alpine:3.12
 COPY --from=builder /app/ /
+RUN apk add --no-cache curl bash
 
+COPY ./entrypoint.sh /
+ENTRYPOINT [ "/entrypoint.sh" ]
 CMD ["./orborus"]

--- a/functions/onprem/orborus/entrypoint.sh
+++ b/functions/onprem/orborus/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# prepare variables
+BASE_URL=${BASE_URL:-http://shuffle-backend:5001}
+
+# wait for backend readiness
+while [ "$(curl -s $BASE_URL/api/v1/_ah/health)" != "OK" ]; do
+    echo "Waiting for backend readiness..."
+    sleep 5
+done
+
+# run main command
+exec "$@"


### PR DESCRIPTION
Even if Frontend service has definition of "depends_on" on Backend, it's getting error below and Frontend's container fails to start until Backend won't be available within Docker Network:
>2020/07/28 08:31:07 [emerg] 1#1: host not found in upstream "shuffle-backend" in /etc/nginx/nginx.conf:52
nginx: [emerg] host not found in upstream "shuffle-backend" in /etc/nginx/nginx.conf:52

This PR updates entrypoint by adding simple wait-script which CURLs Backend's API health-method and waits until it responses "OK".