### PR TITLE
Improved network architecture which makes it working on Kubernetes too

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,7 +24,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o webapp .
 FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
-from scratch
+FROM alpine:3.12
 
 COPY --from=builder /app/ /app
 COPY --from=builder /app_sdk/ /app_sdk

--- a/backend/go-app/docker.go
+++ b/backend/go-app/docker.go
@@ -183,6 +183,7 @@ func buildImageMemory(fs billy.Filesystem, tags []string, dockerfileFolder strin
 		Remove:    true,
 		Tags:      tags,
 		BuildArgs: map[string]*string{},
+		NetworkMode: "host",
 	}
 
 	httpProxy := os.Getenv("HTTP_PROXY")
@@ -245,6 +246,7 @@ func buildImage(tags []string, dockerfileFolder string) error {
 		Remove:    true,
 		Tags:      tags,
 		BuildArgs: map[string]*string{},
+		NetworkMode: "host",
 	}
 
 	httpProxy := os.Getenv("HTTP_PROXY")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   frontend:
-    #build: ./frontend
+    build: ./frontend
     image: frikky/shuffle:frontend
     container_name: shuffle-frontend
     hostname: shuffle-frontend
@@ -16,19 +16,19 @@ services:
     depends_on:
       - backend
   backend:
-    #build: ./backend
+    build: ./backend
     image: frikky/shuffle:backend
     container_name: shuffle-backend
     hostname: ${BACKEND_HOSTNAME}
     # Here for debugging:
-    ports: 
+    ports:
       - "${BACKEND_PORT}:5001"
     networks:
       - shuffle
-    volumes: 
-      - /var/run/docker.sock:/var/run/docker.sock 
-      - ${APP_HOTLOAD_LOCATION}:/shuffle-apps     
-    environment: 
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${APP_HOTLOAD_LOCATION}:/shuffle-apps
+    environment:
       - DATASTORE_EMULATOR_HOST=shuffle-database:8000
       - APP_HOTLOAD_FOLDER=/shuffle-apps
       - ORG_ID=${ORG_ID}
@@ -42,14 +42,14 @@ services:
     depends_on:
       - database
   orborus:
-    #build: ./functions/onprem/orborus
+    build: ./functions/onprem/orborus
     image: frikky/shuffle:orborus
     container_name: shuffle-orborus
     hostname: shuffle-orborus
     networks:
       - shuffle
-    volumes: 
-      - /var/run/docker.sock:/var/run/docker.sock 
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - ORG_ID=${ORG_ID}
       - ENVIRONMENT_NAME=${ENVIRONMENT_NAME}
@@ -60,7 +60,7 @@ services:
       - SHUFFLE_PASS_WORKER_PROXY=${SHUFFLE_PASS_WORKER_PROXY}
     restart: unless-stopped
   database:
-    #build: ./backend/database
+    build: ./backend/database
     image: frikky/shuffle:database
     container_name: shuffle-database
     hostname: shuffle-database

--- a/functions/onprem/orborus/Dockerfile
+++ b/functions/onprem/orborus/Dockerfile
@@ -2,9 +2,9 @@ from golang as builder
 
 RUN mkdir /app
 WORKDIR /app
-COPY orborus.go /app/orborus.go
-
 RUN go get github.com/docker/docker/api/types github.com/docker/docker/api/types/container github.com/docker/docker/client
+
+COPY orborus.go /app/orborus.go
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o orborus .
 

--- a/functions/onprem/orborus/Dockerfile
+++ b/functions/onprem/orborus/Dockerfile
@@ -9,6 +9,7 @@ COPY orborus.go /app/orborus.go
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o orborus .
 
 FROM alpine:3.12
+RUN apk add --no-cache bash
 COPY --from=builder /app/ /
 
 CMD ["./orborus"]

--- a/functions/onprem/orborus/Dockerfile
+++ b/functions/onprem/orborus/Dockerfile
@@ -8,7 +8,7 @@ RUN go get github.com/docker/docker/api/types github.com/docker/docker/api/types
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o orborus .
 
-from scratch
+FROM alpine:3.12
 COPY --from=builder /app/ /
 
 CMD ["./orborus"]

--- a/functions/onprem/orborus/orborus.go
+++ b/functions/onprem/orborus/orborus.go
@@ -112,10 +112,11 @@ func deployWorker(image string, identifier string, env []string) {
 
 	// form container id and use it as network source if it's not empty
 	containerId := getThisContainerId()
+	log.Printf("Found self container id: %s", containerId)
 	if containerId != "" {
 		hostConfig.NetworkMode = container.NetworkMode(fmt.Sprintf("container:%s", containerId))
 	} else {
-		log.Printf("[WARNING] Empty determined container id, continue without NetworkMode")
+		log.Printf("[WARNING] Empty self container id, continue without NetworkMode")
 	}
 
 	// ROFL: https://docker-py.readthedocs.io/en/1.4.0/volumes/

--- a/functions/onprem/orborus/orborus.go
+++ b/functions/onprem/orborus/orborus.go
@@ -87,7 +87,7 @@ func getThisContainerId() string {
 	}
 
 	if fCol != "" {
-		cmd := fmt.Sprintf("head -1 /proc/self/cgroup | cut -d/ -f%s", fCol)
+		cmd := fmt.Sprintf("cat /proc/self/cgroup | grep memory | tail -1 | cut -d/ -f%s", fCol)
 		out, err := exec.Command("bash","-c",cmd).Output()
 		if err == nil {
 			containerId = strings.TrimSpace(string(out))

--- a/functions/onprem/orborus/orborus.go
+++ b/functions/onprem/orborus/orborus.go
@@ -114,9 +114,8 @@ func deployWorker(image string, identifier string, env []string) {
 	containerId := getThisContainerId()
 	if containerId != "" {
 		hostConfig.NetworkMode = container.NetworkMode(fmt.Sprintf("container:%s", containerId))
-		hostConfig.IpcMode = container.IpcMode(fmt.Sprintf("container:%s", containerId))
 	} else {
-		log.Printf("[WARNING] Empty determined container id, continue without NetworkMode/IpcMode")
+		log.Printf("[WARNING] Empty determined container id, continue without NetworkMode")
 	}
 
 	// ROFL: https://docker-py.readthedocs.io/en/1.4.0/volumes/

--- a/functions/onprem/worker/Dockerfile
+++ b/functions/onprem/worker/Dockerfile
@@ -1,21 +1,17 @@
-#from golang as builder
-#
-#RUN mkdir /app
-#WORKDIR /app
-#COPY worker.go /app/worker.go
-#
-#RUN go get github.com/docker/docker/api/types 
-#RUN go get github.com/docker/docker/api/types/container 
-#RUN go get -u github.com/docker/docker/client
-#
-#RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o worker .
-#
+from golang as builder
 
-# THis is a workaround until I get docker/docker to build in a dockerfile
-# PS: This is tricky to google.
-# Might not work on some machines.
-from scratch
-#COPY --from=builder /app/ /
-COPY worker.bin /worker.bin
+WORKDIR /app
 
-CMD ["./worker.bin"]
+RUN go get github.com/docker/docker/api/types && \
+    go get github.com/docker/docker/api/types/container && \
+    go get -u github.com/docker/docker/client
+
+COPY worker.go /app/worker.go
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o worker .
+
+
+FROM alpine:3.12
+RUN apk add --no-cache bash
+COPY --from=builder /app/ /
+
+CMD ["./worker"]

--- a/functions/onprem/worker/worker.go
+++ b/functions/onprem/worker/worker.go
@@ -436,10 +436,11 @@ func deployApp(cli *dockerclient.Client, image string, identifier string, env []
 
 	// form container id and use it as network source if it's not empty
 	containerId := getThisContainerId()
+	log.Printf("Found self container id: %s", containerId)
 	if containerId != "" {
 		hostConfig.NetworkMode = container.NetworkMode(fmt.Sprintf("container:%s", containerId))
 	} else {
-		log.Printf("[WARNING] Empty determined container id, continue without NetworkMode")
+		log.Printf("[WARNING] Empty self container id, continue without NetworkMode")
 	}
 
 	config := &container.Config{

--- a/functions/onprem/worker/worker.go
+++ b/functions/onprem/worker/worker.go
@@ -426,16 +426,21 @@ func getThisContainerId() string {
 
 // Deploys the internal worker whenever something happens
 func deployApp(cli *dockerclient.Client, image string, identifier string, env []string) error {
-	// figure out current container id
-	containerId := getThisContainerId()
-
+	// form basic hostConfig
 	hostConfig := &container.HostConfig{
-		NetworkMode: container.NetworkMode(fmt.Sprintf("container:%s", containerId)),
-		IpcMode: container.IpcMode(fmt.Sprintf("container:%s", containerId)),
 		LogConfig: container.LogConfig{
 			Type:   "json-file",
 			Config: map[string]string{},
 		},
+	}
+
+	// form container id and use it as network source if it's not empty
+	containerId := getThisContainerId()
+	if containerId != "" {
+		hostConfig.NetworkMode = container.NetworkMode(fmt.Sprintf("container:%s", containerId))
+		hostConfig.IpcMode = container.IpcMode(fmt.Sprintf("container:%s", containerId))
+	} else {
+		log.Printf("[WARNING] Empty determined container id, continue without NetworkMode/IpcMode")
 	}
 
 	config := &container.Config{

--- a/functions/onprem/worker/worker.go
+++ b/functions/onprem/worker/worker.go
@@ -438,9 +438,8 @@ func deployApp(cli *dockerclient.Client, image string, identifier string, env []
 	containerId := getThisContainerId()
 	if containerId != "" {
 		hostConfig.NetworkMode = container.NetworkMode(fmt.Sprintf("container:%s", containerId))
-		hostConfig.IpcMode = container.IpcMode(fmt.Sprintf("container:%s", containerId))
 	} else {
-		log.Printf("[WARNING] Empty determined container id, continue without NetworkMode/IpcMode")
+		log.Printf("[WARNING] Empty determined container id, continue without NetworkMode")
 	}
 
 	config := &container.Config{

--- a/functions/onprem/worker/worker.go
+++ b/functions/onprem/worker/worker.go
@@ -415,7 +415,7 @@ func shutdown(executionId, workflowId string) {
 // form container id of current running container
 func getThisContainerId() string {
 	containerId := ""
-	cmd := fmt.Sprintf("head -1 /proc/self/cgroup | cut -d/ -f3")
+	cmd := fmt.Sprintf("cat /proc/self/cgroup | grep memory | tail -1 | cut -d/ -f3")
 	out, err := exec.Command("bash","-c",cmd).Output()
 	if err == nil {
 		containerId = strings.TrimSpace(string(out))

--- a/functions/stitcher.go
+++ b/functions/stitcher.go
@@ -101,15 +101,15 @@ func getRunner(classname string) string {
 	return fmt.Sprintf(`
 # Run the actual thing after we've checked params
 def run(request):
-    action = request.get_json() 
+    action = request.get_json()
     print(action)
     print(type(action))
     authorization_key = action.get("authorization")
     current_execution_id = action.get("execution_id")
-	
+
     if action and "name" in action and "app_name" in action:
         asyncio.run(%s.run(action), debug=True)
-        return f'Attempting to execute function {action["name"]} in app {action["app_name"]}' 
+        return f'Attempting to execute function {action["name"]} in app {action["app_name"]}'
     else:
         return f'Invalid action'
 
@@ -610,6 +610,7 @@ func buildImage(client *client.Client, tags []string, dockerBuildCtxDir string) 
 			PullParent: true,
 			Remove:     true,
 			Tags:       tags,
+			NetworkMode: "host",
 		},
 	)
 


### PR DESCRIPTION
Suggestion to change configuration of created by orborus/worker Docker containers. At the moment we have to determine network name and pass it to child containers. After investigation I found how we can improve architecture and as a bonus make Shuffle working on Kubernetes cluster (current implementation doesn't work on K8s as Docker Compose and K8s uses network little different). I tested on local Minikube cluster only yet.
The main idea is that instead of creating Network Endpoint with required network name, we would pass to created Docker-container HostConfig's "NetworkMode" & "IpcMode" with value "container:12345", where "12345" - is parent's container id (orborus/worker). So new created container will take full network settings from passed container id. When orborus would create worker, it would determine self-container-id and pass configurated NetworkMode/IpcMode params with included self-container-id. That new worker when creating apps will pass self container's id too. So all chain's containers will be located in the same network wherever Shuffle's stack runs in Docker or Kubernetes mode.
![image](https://user-images.githubusercontent.com/37391150/89116811-ecbebb00-d4a0-11ea-9680-a14da401feaa.png)

https://docs.docker.com/engine/api/v1.24/
>NetworkMode - Sets the networking mode for the container. Supported standard values are: bridge, host, none, and container:<name|id>. Any other value is taken as a custom network’s name to which this container should connect to.

TODO. It should be more right to implement creating worker & apps as temporary pods+services when running in K8s mode, but such solution is a much longer to implement and suggested solution is really much easier, so it makes sense.

P.S. I had to replace Scratch with Alpine as Scratch+Minikube didn't work properly with downloading remote data via https. Also we have to get access to Docker's file system (we need file /proc/self/cgroup) to figure out container's id.