### PR TITLE
Stop using magic init function

### DIFF
--- a/backend/go-app/main.go
+++ b/backend/go-app/main.go
@@ -6449,7 +6449,7 @@ func runInit(ctx context.Context) {
 	log.Printf("Finished INIT")
 }
 
-func init() {
+func initHandlers() {
 	var err error
 	ctx := context.Background()
 
@@ -6575,7 +6575,7 @@ func init() {
 
 // Had to move away from mux, which means Method is fucked up right now.
 func main() {
-	//init()
+	initHandlers()
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = "MISSING"


### PR DESCRIPTION
To be able to write tests we need to get rid of `init()` because we can't have it running when we run tests.
