### PR TITLE
add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+**/.git*
+**/.gitlab-ci.yml
+**/.env
+**/.dockerignore
+**/Dockerfile*
+**/node_modules
+buildSrc/libs
+.gradle/
+build/
+**build/
+.idea/
+!.idea/codeStyles/codeStyleConfig.xml
+.DS_Store
+*.log
+out/


### PR DESCRIPTION
To reach development best practices .dockerignore file has been added. With it no additional context would be send when Docker images are building.