### PR TITLE
Printf should have one argument per directive

### DIFF
--- a/backend/go-app/codegen.go
+++ b/backend/go-app/codegen.go
@@ -483,7 +483,7 @@ func generateYaml(swagger *openapi3.Swagger, newmd5 string) (*openapi3.Swagger, 
 			var parse parsed
 			err := json.Unmarshal([]byte(parsedCategories), &parse)
 			if err != nil {
-				log.Printf("Failed unmarshaling categories", err)
+				log.Printf("Failed unmarshaling categories: %v", err)
 			} else {
 				api.Categories = parse.Categories
 			}

--- a/backend/go-app/main.go
+++ b/backend/go-app/main.go
@@ -861,7 +861,7 @@ func deleteUser(resp http.ResponseWriter, request *http.Request) {
 
 	err = setUser(ctx, foundUser)
 	if err != nil {
-		log.Printf("Failed swapping active for user %s (%s)", foundUser, foundUser.Username, foundUser.Id)
+		log.Printf("Failed swapping active for user %s (%s)", foundUser.Username, foundUser.Id)
 		resp.WriteHeader(401)
 		resp.Write([]byte(fmt.Sprintf(`{"success": false}`)))
 		return
@@ -2017,7 +2017,7 @@ func handlePasswordChange(resp http.ResponseWriter, request *http.Request) {
 		if len(users) != 1 {
 			log.Printf(`Found multiple or no users with the same username: %s: %d`, t.Username, len(users))
 			resp.WriteHeader(401)
-			resp.Write([]byte(fmt.Sprintf(`{"success": false, "reason": "Found %d users with the same username: %s (%d)"}`, len(users), t.Username)))
+			resp.Write([]byte(fmt.Sprintf(`{"success": false, "reason": "Found %d users with the same username: %s"}`, len(users), t.Username)))
 			return
 		}
 
@@ -2485,7 +2485,7 @@ func handleLogin(resp http.ResponseWriter, request *http.Request) {
 	}
 
 	if !Userdata.Active {
-		log.Printf("%s is not active, but tried to login", data.Username, err)
+		log.Printf("%s is not active, but tried to login. Error: %v", data.Username, err)
 		resp.WriteHeader(401)
 		resp.Write([]byte(`{"success": false, "reason": "This user is deactivated"}`))
 		return
@@ -3484,7 +3484,7 @@ func handleWebhookCallback(resp http.ResponseWriter, request *http.Request) {
 func executeCloudAction(action CloudSyncJob, apikey string) error {
 	data, err := json.Marshal(action)
 	if err != nil {
-		log.Printf("Failed cloud webhook action marshalling", err)
+		log.Printf("Failed cloud webhook action marshalling: %s", err)
 		return err
 	}
 
@@ -5289,7 +5289,7 @@ func handleGetSpecificStats(resp http.ResponseWriter, request *http.Request) {
 
 	b, err := json.Marshal(statisticsItem)
 	if err != nil {
-		log.Println("Failed to marshal data: %s", err)
+		log.Printf("Failed to marshal data: %s", err)
 		resp.WriteHeader(401)
 		return
 	}
@@ -7789,7 +7789,7 @@ func handleCloudSetup(resp http.ResponseWriter, request *http.Request) {
 	if err != nil {
 		log.Printf("Failed marshaling api key data: %s", err)
 		resp.WriteHeader(401)
-		resp.Write([]byte(fmt.Sprintf(`{"success": false, "reason": "Failed cloud sync."}`, err)))
+		resp.Write([]byte(fmt.Sprintf(`{"success": false, "reason": "Failed cloud sync: %s"}`, err)))
 		return
 	}
 

--- a/backend/go-app/walkoff.go
+++ b/backend/go-app/walkoff.go
@@ -16,10 +16,10 @@ import (
 	"time"
 
 	"cloud.google.com/go/datastore"
-	"cloud.google.com/go/scheduler/apiv1"
+	scheduler "cloud.google.com/go/scheduler/apiv1"
 	gyaml "github.com/ghodss/yaml"
 	"github.com/h2non/filetype"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"google.golang.org/api/cloudfunctions/v1"
 	schedulerpb "google.golang.org/genproto/googleapis/cloud/scheduler/v1"
 
@@ -2857,7 +2857,7 @@ func handleExecution(id string, workflow Workflow, request *http.Request) (Workf
 	}
 
 	if len(allEnvs) == 0 {
-		log.Printf("[ERROR] No active environments found for org", workflowExecution.ExecutionOrg)
+		log.Printf("[ERROR] No active environments found for org: %s", workflowExecution.ExecutionOrg)
 		return WorkflowExecution{}, "No active environments found", errors.New(fmt.Sprintf("No active env found for org %s", workflowExecution.ExecutionOrg))
 	}
 
@@ -3212,7 +3212,7 @@ func stopSchedule(resp http.ResponseWriter, request *http.Request) {
 
 		err = executeCloudAction(action, org.SyncConfig.Apikey)
 		if err != nil {
-			log.Printf("Failed cloud action STOP schedule", err)
+			log.Printf("Failed cloud action STOP schedule: %s", err)
 			resp.WriteHeader(401)
 			resp.Write([]byte(fmt.Sprintf(`{"success": false, "reason": "%s"}`, err)))
 			return
@@ -3553,7 +3553,7 @@ func scheduleWorkflow(resp http.ResponseWriter, request *http.Request) {
 
 		err = setSchedule(ctx, newSchedule)
 		if err != nil {
-			log.Printf("Failed setting cloud schedule: returning", err)
+			log.Printf("Failed setting cloud schedule: %s", err)
 			resp.WriteHeader(401)
 			resp.Write([]byte(fmt.Sprintf(`{"success": false, "reason": "%s"}`, err)))
 			return
@@ -3562,7 +3562,7 @@ func scheduleWorkflow(resp http.ResponseWriter, request *http.Request) {
 		log.Printf("Action: %#v", action)
 		err = executeCloudAction(action, org.SyncConfig.Apikey)
 		if err != nil {
-			log.Printf("Failed cloud action START schedule", err)
+			log.Printf("Failed cloud action START schedule: %s", err)
 			resp.WriteHeader(401)
 			resp.Write([]byte(fmt.Sprintf(`{"success": false, "reason": "%s"}`, err)))
 			return
@@ -5986,7 +5986,7 @@ func handleDeleteHook(resp http.ResponseWriter, request *http.Request) {
 
 		err = executeCloudAction(action, org.SyncConfig.Apikey)
 		if err != nil {
-			log.Printf("Failed cloud action STOP execution", err)
+			log.Printf("Failed cloud action STOP execution: %s", err)
 			resp.WriteHeader(401)
 			resp.Write([]byte(fmt.Sprintf(`{"success": false, "reason": "%s"}`, err)))
 			return


### PR DESCRIPTION
This is just a cleanup commit to make `go` stop complaining about errors like this:

```
./walkoff.go:5999:14: Printf call has arguments but no formatting directives
```

I am not very familiar with the functions and use cases, so please correct me if I have chosen to print a variable that shouldn't be printed, or vice versa.