### PR TITLE
ci init

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,66 @@
+name: ci
+
+on:
+  push:
+    branches: master
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+         - app: frontend
+           path: frontend
+           version: 0.8.3
+           experimental: true
+         - app: backend
+           path: backend
+           version: 0.8.3
+           experimental: false
+         - app: orborus
+           path: functions/onprem/orborus
+           version: 0.8.0
+           experimental: false
+         - app: database
+           path: backend/database
+           version: 0.8.0
+           experimental: false
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#        Use below configuration for ghcr.io
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }} 
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        env:
+          BUILDX_NO_DEFAULT_LOAD: true
+        with:
+          context: ${{ matrix.path }}/
+          file: ${{ matrix.path }}/Dockerfile          
+          platforms: linux/amd64,linux/arm64
+          #,linux/386 - no node image I guess?
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.app }}:${{ matrix.version }}
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
 Everything works except for the frontend npm stuff. I don't know enough about how the frontend is built yet to fix it myself. Ln9 `continue-on-error: ${{ matrix.experimental }}` allows the rest of the images to continue being built while the frontend is fixed.