### PR TITLE
Can't see full result in frontend when not JSON #241

### DIFF
--- a/frontend/src/views/AngularWorkflow.jsx
+++ b/frontend/src/views/AngularWorkflow.jsx
@@ -6615,7 +6615,7 @@ const AngularWorkflow = (props) => {
 										}
 										</span>
 									: 
-									<div style={{maxHeight: 250, overflowX: "hidden", overflowY: "scroll",}}>
+									<div style={{maxHeight: 250, overflowX: "hidden", overflowY: "auto",}}>
 										<b>Result</b>&nbsp;
 										{data.result}
 									</div>

--- a/frontend/src/views/AngularWorkflow.jsx
+++ b/frontend/src/views/AngularWorkflow.jsx
@@ -566,6 +566,9 @@ const AngularWorkflow = (props) => {
 						}
 						break
 					case "FAILURE": 
+						//When status comes as failure, allow user to start workflow execution
+						setExecutionRunning(false)
+
 						currentnode.removeClass('not-executing-highlight')
 						currentnode.removeClass('executing-highlight')
 						currentnode.removeClass('success-highlight')


### PR DESCRIPTION
Now all execution responses will be visible properly irrespective of response type.