### PR TITLE
fix build with using golang:latest

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-from golang as builder
+FROM golang:1.16.0-buster as builder
 
 # Add files
 RUN mkdir /app

--- a/functions/onprem/orborus/Dockerfile
+++ b/functions/onprem/orborus/Dockerfile
@@ -1,4 +1,4 @@
-from golang as builder
+FROM golang:1.16.0-buster as builder
 
 RUN mkdir /app
 WORKDIR /app
@@ -6,6 +6,12 @@ RUN go get github.com/docker/docker/api/types github.com/docker/docker/api/types
 
 COPY orborus.go /app/orborus.go
 RUN go mod init orborus 
+RUN go get github.com/docker/docker/api/types && \
+    go get github.com/docker/docker/api/types/container && \
+    go get github.com/docker/docker/client && \
+    go get github.com/mackerelio/go-osstat/cpu && \
+    go get github.com/mackerelio/go-osstat/memory && \
+    go get github.com/satori/go.uuid
 RUN go build
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o orborus .
 

--- a/functions/onprem/worker/Dockerfile
+++ b/functions/onprem/worker/Dockerfile
@@ -1,4 +1,4 @@
-from golang as builder
+FROM golang:1.16.0-buster as builder
 
 WORKDIR /app
 
@@ -9,7 +9,13 @@ RUN go get -u github.com/gorilla/mux
 RUN go get -u github.com/patrickmn/go-cache
 
 COPY worker.go /app/worker.go
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o worker .
+RUN go env -w GO111MODULE=auto && \
+    go get github.com/docker/docker/api/types && \
+    go get github.com/docker/docker/api/types/container && \
+    go get github.com/docker/docker/client && \
+    go get github.com/gorilla/mux && \
+    go get github.com/patrickmn/go-cache && \
+    CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o worker .
 
 FROM alpine:3.12
 


### PR DESCRIPTION
Fix failed Docker builds for these services: **backend, orborus, worker** because of such error:

> go: cannot find main module; see 'go help modules'

Docker image golang:latest has changed, so also it would be better to define concrete golang version in image tag.