### PR TITLE
frontend: fix Webpack issue on building Docker image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Build environment
-FROM node as builder
+FROM node:14 as builder
 
 RUN mkdir /usr/src/app
 
@@ -17,10 +17,6 @@ COPY ./public /usr/src/app/public/
 COPY ./src /usr/src/app/src/
 COPY ./*.sh /usr/src/app/
 COPY ./*.json /usr/src/app/
-
-# There were issues with the webpack installer from package.json
-RUN rm -rf /usr/src/app/node_modules/webpack
-#RUN yarn add webpack@4.42.0
 
 RUN yarn build
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,7 @@
     "shellwords": "^0.1.1",
     "simplebar": "^4.2.3",
     "styled-components": "^4.4.0",
-    "webpack": "^4.42.0",
+    "webpack": "4.44.2",
     "websocket": "^1.0.30",
     "yaml": "^1.7.2",
     "yamljs": "^0.3.0",


### PR DESCRIPTION
Suggestion to define concrete versions of Webpack and Docker "node" image to make it always buildable.