### PR TITLE
improve work with Kubernetes

### DIFF
--- a/functions/onprem/orborus/orborus.go
+++ b/functions/onprem/orborus/orborus.go
@@ -106,7 +106,7 @@ func getThisContainerId() {
 	}
 
 	if fCol != "" {
-		cmd := fmt.Sprintf("cat /proc/self/cgroup | grep memory | tail -1 | cut -d/ -f%s", fCol)
+		cmd := fmt.Sprintf("cat /proc/self/cgroup | grep memory | tail -1 | cut -d/ -f%s | grep -o -E '[0-9A-z]{64}'", fCol)
 		out, err := exec.Command("bash", "-c", cmd).Output()
 		if err == nil {
 			containerId = strings.TrimSpace(string(out))

--- a/functions/onprem/worker/worker.go
+++ b/functions/onprem/worker/worker.go
@@ -53,7 +53,7 @@ var containerId string
 // form container id of current running container
 func getThisContainerId() string {
 	id := ""
-	cmd := fmt.Sprintf("cat /proc/self/cgroup | grep memory | tail -1 | cut -d/ -f3")
+	cmd := fmt.Sprintf("cat /proc/self/cgroup | grep memory | tail -1 | cut -d/ -f3 | grep -o -E '[0-9A-z]{64}'")
 	out, err := exec.Command("bash", "-c", cmd).Output()
 	if err == nil {
 		id = strings.TrimSpace(string(out))
@@ -861,6 +861,7 @@ func deployApp(cli *dockerclient.Client, image string, identifier string, env []
 	}
 
 	// form container id and use it as network source if it's not empty
+	containerId = getThisContainerId()
 	if containerId != "" {
 		hostConfig.NetworkMode = container.NetworkMode(fmt.Sprintf("container:%s", containerId))
 	} else {


### PR DESCRIPTION
Improvements of containerID calculation based on live Kubernetes deployments.

Also I've added additional calculation of actual containerId `containerId = getThisContainerId()` because I found that sometimes containerId was empty, i.e. calculation of containerId at start was not enough.