### PR TITLE
make build-instruction in compose file to always be available

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   frontend:
-    #build: ./frontend
+    build: ./frontend
     image: ghcr.io/frikky/shuffle-frontend:0.8.60
     container_name: shuffle-frontend
     hostname: shuffle-frontend
@@ -16,7 +16,7 @@ services:
     depends_on:
       - backend
   backend:
-    #build: ./backend
+    build: ./backend
     image: ghcr.io/frikky/shuffle-backend:0.8.60
     container_name: shuffle-backend
     hostname: ${BACKEND_HOSTNAME}
@@ -44,7 +44,7 @@ services:
     depends_on:
       - database
   orborus:
-    #build: ./functions/onprem/orborus
+    build: ./functions/onprem/orborus
     image: ghcr.io/frikky/shuffle-orborus:0.8.60
     container_name: shuffle-orborus
     hostname: shuffle-orborus
@@ -69,7 +69,7 @@ services:
       - CLEANUP=${SHUFFLE_CONTAINER_AUTO_CLEANUP}
     restart: unless-stopped
   database:
-    #build: ./backend/database
+    build: ./backend/database
     image: frikky/shuffle:database
     container_name: shuffle-database
     hostname: shuffle-database


### PR DESCRIPTION
We don't have to comment/uncomment "build" instruction every time. To use remote images, we can just run **docker-compose pull** which will rewrite local images with names described in docker compose file. And to build local images, which vice versa will rewrite remote Docker images, we can run **docker-compose build**. That commands are not conflict with each other.