### PR TITLE
Update docker-compose.yml to use opensearch:1.0.0 instead of beta

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,18 +25,18 @@ services:
       - "${BACKEND_PORT}:5001"
     networks:
       - shuffle
-    volumes: 
-      - /var/run/docker.sock:/var/run/docker.sock 
-      - ${SHUFFLE_APP_HOTLOAD_LOCATION}:/shuffle-apps     
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${SHUFFLE_APP_HOTLOAD_LOCATION}:/shuffle-apps
       - ${SHUFFLE_FILE_LOCATION}:/shuffle-files
       #- ${SHUFFLE_OPENSEARCH_CERTIFICATE_FILE}:/shuffle-files/es_certificate
-    env_file: .env 
+    env_file: .env
     environment:
       - SHUFFLE_APP_HOTLOAD_FOLDER=/shuffle-apps
       - SHUFFLE_FILE_LOCATION=/shuffle-files
     restart: unless-stopped
     #depends_on:
-      #- opensearch 
+      #- opensearch
       #- database
   orborus:
     #build: ./functions/onprem/orborus
@@ -66,13 +66,13 @@ services:
       - CLEANUP=${SHUFFLE_CONTAINER_AUTO_CLEANUP}
     restart: unless-stopped
   opensearch:
-    image: opensearchproject/opensearch:1.0.0-beta1
+    image: opensearchproject/opensearch:1.0.0
     hostname: shuffle-opensearch
     container_name: shuffle-opensearch
     environment:
-      - bootstrap.memory_lock=true 
+      - bootstrap.memory_lock=true
       - "OPENSEARCH_JAVA_OPTS=-Xms1024m -Xmx1024m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
-      - opendistro_security.disabled=true
+      - plugins.security.disabled=true
       - cluster.routing.allocation.disk.threshold_enabled=false
       - cluster.name=shuffle-cluster
       - node.name=shuffle-opensearch


### PR DESCRIPTION
change made on the docker-compose.yml to use the official release of opensearch:1.0.0 .

Parameter  opendistro_security.disabled=true changed to plugins.security.disabled=true as this is the proper way to call it.

Some testing need to be done on other stack to make sur this change is safe.