### PR TITLE
Vulnerability fix for CVE 2021-44228 (Log4J)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       - CLEANUP=${SHUFFLE_CONTAINER_AUTO_CLEANUP}
     restart: unless-stopped
   opensearch:
-    image: opensearchproject/opensearch:1.2.1
+    image: opensearchproject/opensearch:1.2.3
     hostname: shuffle-opensearch
     container_name: shuffle-opensearch
     environment:


### PR DESCRIPTION
This PR contains latest vulnerability fix for Log4J RCE (CVE 2021-44228)
Reference: https://opensearch.org/blog/releases/2021/12/update-1-2-3/ 