### PR TITLE
Update install-guide.md

### DIFF
--- a/.github/install-guide.md
+++ b/.github/install-guide.md
@@ -17,7 +17,7 @@ cd Shuffle
 
 3. Fix prerequisites for the Opensearch database (Elasticsearch): 
 ```
-sudo chown 1000:1000 -R shuffle-database 		# Required for Opensearch 
+sudo chown -R 1000:1000 shuffle-database 		# Required for Opensearch 
 ```
 
 4. Run docker-compose.


### PR DESCRIPTION
fixing the guide for the chown command. The current guide results in an error '''chown: -R: No such file or directory'''